### PR TITLE
Fix proxy pool: apply controller-assigned proxy to tls-client backend

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -78,6 +78,18 @@ func (a *Agent) registerLoop() {
 		resp.Body.Close()
 
 		a.agentID = regResp.AgentID
+
+		// Apply proxy from controller if assigned and backend supports it
+		if regResp.Proxy != nil && regResp.Proxy.URL != "" {
+			if ps, ok := a.backend.(ProxySetter); ok {
+				if err := ps.SetProxy(regResp.Proxy); err != nil {
+					log.Printf("failed to set proxy from controller: %v", err)
+				} else {
+					log.Printf("registered with controller as %s (ip=%s, proxy=%s)", a.agentID, ip, regResp.Proxy.URL)
+					return
+				}
+			}
+		}
 		log.Printf("registered with controller as %s (ip=%s)", a.agentID, ip)
 		return
 	}

--- a/internal/agent/backend.go
+++ b/internal/agent/backend.go
@@ -19,6 +19,11 @@ type BrowserBackend interface {
 	Close() error
 }
 
+// ProxySetter is an optional interface for backends that support runtime proxy assignment.
+type ProxySetter interface {
+	SetProxy(proxy *api.ProxyConfig) error
+}
+
 // StubBackend is a simple HTTP-fetch backend for testing the orchestration layer.
 // No real browser — just proves the plumbing works.
 type StubBackend struct {

--- a/internal/agent/tlsclient.go
+++ b/internal/agent/tlsclient.go
@@ -173,6 +173,19 @@ func (t *TLSClientBackend) SetCookies(targetURL string, cookies []api.Cookie) er
 	return nil
 }
 
+// SetProxy applies a proxy at runtime (called when controller assigns from pool).
+func (t *TLSClientBackend) SetProxy(proxy *api.ProxyConfig) error {
+	proxyURL := proxy.URL
+	if proxy.Username != "" {
+		proxyURL = insertProxyAuth(proxy.URL, proxy.Username, proxy.Password)
+	}
+	if err := t.client.SetProxy(proxyURL); err != nil {
+		return fmt.Errorf("setting proxy: %w", err)
+	}
+	log.Printf("tls-client proxy set: %s", proxy.URL)
+	return nil
+}
+
 func (t *TLSClientBackend) Health() api.HealthStatus {
 	return api.HealthStatus{
 		Status:  api.HealthOK,


### PR DESCRIPTION
## Problem

The proxy pool feature (#8) assigns proxies at registration but the agent never applies them. The `RegisterResponse.Proxy` was returned by the controller but thrown away by the agent. All minnow requests went through the host IP.

## Fix

- Add `ProxySetter` interface to `backend.go`
- Implement `SetProxy` on `TLSClientBackend` — calls `client.SetProxy()` with auth URL
- In `agent.go` `registerLoop`, check if controller assigned a proxy and apply it via `ProxySetter`

## Verification

Before: all minnows → `162.193.24.34` (home IP)
After: all minnows → residential proxy IPs (`168.158.184.163`, `72.1.133.7`, etc.)

```
tls-client proxy set: http://168.158.184.163:6174
registered with controller as pompano-34059735 (ip=162.193.24.34, proxy=http://168.158.184.163:6174)
```

httpbin confirms: `"origin": "168.158.184.163"`

## Note

There's still a separate issue where 1-2 minnows per cluster have completely dead tls-client instances (0 visits, 0 cookies, empty responses on everything including httpbin). This isn't a proxy issue — those instances can't make any request at all. Filed as a comment on #2.